### PR TITLE
Update to support new caskroom path

### DIFF
--- a/bin/brew-cask-upgrade
+++ b/bin/brew-cask-upgrade
@@ -20,6 +20,6 @@ outdated.each do |app|
   puts "==> Upgrading #{app[:name]}"
   system "brew cask install #{app[:name]} --force"
   app[:installed].each do |version|
-    system "rm -rf /opt/homebrew-cask/Caskroom/#{app[:name]}/#{version}"
+    system "rm -rf #{CASKROOM}/#{app[:name]}/#{version}"
   end
 end

--- a/lib/brew-cask-upgrade.rb
+++ b/lib/brew-cask-upgrade.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift("#{CASK_HOME}/lib")
 require 'vendor/homebrew-fork/global'
 require 'hbc'
 
-CASKROOM = "/opt/homebrew-cask/Caskroom"
+CASKROOM = "/usr/local/Caskroom"
 
 def each_installed
   Hbc.installed.each_with_index do |name, i|


### PR DESCRIPTION
Homebrew-Cask changed its default Caskroom location:
https://github.com/caskroom/homebrew-cask/issues/21603
https://github.com/caskroom/homebrew-cask/pull/21857