### PR TITLE
Fix 'invalid characters' error by filtering hidden directories

### DIFF
--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -75,7 +75,9 @@ module Cask
 
   # Retrieves currently installed versions on the machine.
   def self.installed_versions(token)
-    Dir["#{CASKROOM}/#{token}/*"].map { |e| File.basename e }
+    Dir["#{CASKROOM}/#{token}/*"]
+      .map { |e| File.basename e }
+      .reject { |v| v.start_with?(".") } # Filter out hidden files like .metadata
   end
 
   def self.brew_update(verbose)


### PR DESCRIPTION
## Problem

Users were experiencing the following error when running `brew cu`:

```
!contains invalid characters:
/opt/homebrew/Library/Homebrew/cask/dsl/version.rb:71:in `initialize`
```

The error occurred when `installed_versions` method returned directory names that included hidden files (like `.metadata`) or other directories starting with `.`, which are not valid version strings. When these were passed to `DSL::Version.new()`, it threw an error.

Ref: https://github.com/buo/homebrew-cask-upgrade/issues/260

## Solution

Modified the `installed_versions` method in `lib/extend/cask.rb` to filter out hidden directories using `.reject { |v| v.start_with?(".") }`.

This ensures only valid version directory names are processed, preventing the error while maintaining all existing functionality.

## Testing

- Verified the fix resolves the reported error
- No breaking changes to existing functionality
- Hidden system directories like `.metadata` are now properly excluded from version detection