### PR TITLE
Complete the info for MAS apps

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -115,7 +115,7 @@ module Bcu
           current:            data[3],
           outdated?:          !new_version.nil?,
           auto_updates:       false,
-          homepage:           "https://apps.apple.com/" + region + "/app/id" + mas_id,
+          homepage:           "https://apps.apple.com/#{region}/app/id#{mas_id}",
           installed_versions: [data[3]],
           mas:                true,
           mas_id:             mas_id,


### PR DESCRIPTION
Currently, MAS apps lack the "full" latest/current string and also the homepage. This PR attempts to fill this gap by using the normal version string for the full string (as there should be no dashes in MAS version strings), while also compiling a homepage string from MAS ID. Technically, a better approach would be to run `mas list <app-id>` for each app and fetch the homepage, but I fear that doing it this way will be too slow.

Before (with `-v` supplied):
<img width="3178" height="430" alt="CleanShot 2025-11-27 at 22 34 52@2x" src="https://github.com/user-attachments/assets/2377c5fc-49e6-4afc-be37-1e886678f29d" />

After:
<img width="3180" height="430" alt="CleanShot 2025-11-27 at 22 35 04@2x" src="https://github.com/user-attachments/assets/433f23c6-b676-4134-83bd-9905e48ec602" />