### PR TITLE
Pass multiple app argument to brew reinstall

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -265,7 +265,7 @@ module Bcu
 
     def parse_mas_app(app)
       match = app.strip.split(/^(\d+)\s+(.+?)\s+\((.+)\)$/)
-      version_upgrade = match[3].split(" -> ") 
+      version_upgrade = match[3].split(" -> ")
       if version_upgrade.length == 2
         installed_version = version_upgrade[0]
         version = version_upgrade[1]
@@ -274,10 +274,10 @@ module Bcu
         version = nil
       end
       {
-        id: match[1],
-        name: match[2].downcase.strip, 
+        id:                match[1],
+        name:              match[2].downcase.strip,
         installed_version: installed_version,
-        new_version: version
+        new_version:       version,
       }
     end
 


### PR DESCRIPTION
This PR tries to change the way `brew cu` calls `brew reinstall`, so that only one command `brew reinstall app1 app2 ...` is issued instead of calling reinstall for each app. This has multiple advantages:
- Avoid entering the root password multiple times (Should fix #266).
- Since `brew` already has parallel download support, this should also resolve #160 with no extra efforts needed.

Interactive mode is also supported, as the apps are already collected anyway. MAS apps are passed as a single command to `mas upgrade` too.

The output is changed to "Update N apps", and the version for updated apps is printed if `-v` is passed. The version format mirrors the vanilla `brew upgrade` format.

Screenshot:
<img width="3456" height="754" alt="CleanShot 2025-11-30 at 19 11 47@2x" src="https://github.com/user-attachments/assets/57f5644a-008d-4c1f-8091-161693feace2" />