### PR TITLE
Change to use mas config for region detection

### DIFF
--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -90,7 +90,8 @@ module Bcu
       result = IO.popen(%w[mas list]).read
       mac_apps = result.split("\n")
 
-      region = IO.popen(%w[mas region]).read.strip.downcase
+      region = IO.popen(%w[mas config]).read.lines
+                 .find { |l| l.start_with?("region") }.split.last.downcase
 
       mas_outdated = mas_load_outdated
 


### PR DESCRIPTION
As `mas region` was removed in [mas#1167](https://github.com/mas-cli/mas/pull/1167), change to use `mas config` to detect the region the user is currently in instead.