### PR TITLE
Fix glob pattern filtering not displaying filtered cask list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ You can use glob patterns to upgrade multiple casks at once. The following patte
 
 ```bash
 # Correct - quoted
-brew cu 'cl*'
+brew cu 'firefox*'
 
 # Correct - escaped
-brew cu cl\*
+brew cu firefox\*
 
 # Also works in zsh
-noglob brew cu cl*
+noglob brew cu firefox*
 
-# Incorrect - shell will try to expand cl* before passing to brew
-brew cu cl*
+# Incorrect - shell will try to expand firefox* before passing to brew
+brew cu firefox*
 ```
 
 [![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,29 @@ brew cu [CASK]
 While running the `brew cu` command without any other further options, the script automatically runs `brew update` to get
 latest versions of all the installed casks (this can be disabled, see options below).
 
-It is also possible to use `*` to install multiple casks at once, i.e. `brew cu flash-*` to install all casks starting with `flash-` prefix.
+### Glob Patterns
+
+You can use glob patterns to upgrade multiple casks at once. The following patterns are supported:
+
+- `*` - matches any characters (e.g., `brew cu 'flash-*'` upgrades all casks starting with `flash-`)
+- `?` - matches a single character (e.g., `brew cu 'app?'` matches `app1`, `app2`, etc.)
+- `[abc]` - matches any character in the brackets (e.g., `brew cu 'app[123]'`)
+
+**Important:** Always **quote** or escape glob patterns to prevent shell expansion:
+
+```bash
+# Correct - quoted
+brew cu 'cl*'
+
+# Correct - escaped
+brew cu cl\*
+
+# Also works in zsh
+noglob brew cu cl*
+
+# Incorrect - shell will try to expand cl* before passing to brew
+brew cu cl*
+```
 
 [![asciicast](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW.png)](https://asciinema.org/a/DlXUmiFFVnDhIDe2tCGo3ecLW)
 

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -12,7 +12,7 @@
 #:      to upgrade multiple apps (e.g., `brew cu 'flash-*'`
 #:      to upgrade all flash-related casks).
 #:      **Important:** Always quote or escape patterns to prevent
-#:      shell expansion (e.g., `brew cu 'cl*'` or `brew cu cl\*`).
+#:      shell expansion (e.g., `brew cu 'firefox*'` or `brew cu firefox\*`).
 #:
 #:   `cu pin` CASK
 #:      Pin the current CASK version, preventing it from being

--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -8,10 +8,11 @@
 #:      Upgrade every outdated app installed by `brew cask`.
 #:
 #:   `cu` CASK [`options`]
-#:      Upgrade a specific app. You can use star
-#:      to include more apps (`brew cu flash-**`)
-#:      to upgrade all flash related casks
-#:      (might require escaping `brew cu flash-\*`).
+#:      Upgrade a specific app. You can use glob patterns
+#:      to upgrade multiple apps (e.g., `brew cu 'flash-*'`
+#:      to upgrade all flash-related casks).
+#:      **Important:** Always quote or escape patterns to prevent
+#:      shell expansion (e.g., `brew cu 'cl*'` or `brew cu cl\*`).
 #:
 #:   `cu pin` CASK
 #:      Pin the current CASK version, preventing it from being

--- a/lib/bcu/command/upgrade.rb
+++ b/lib/bcu/command/upgrade.rb
@@ -34,7 +34,7 @@ module Bcu
       include_mas_applications installed if options.include_mas
 
       ohai "Finding outdated apps"
-      outdated, state_info = find_outdated_apps(installed, options)
+      outdated, state_info, installed = find_outdated_apps(installed, options)
       Formatter.print_app_table(installed, state_info, options) unless options.quiet
       if outdated.empty?
         puts "No outdated apps found." if options.quiet
@@ -243,7 +243,12 @@ module Bcu
         installed = installed.select do |app|
           found = false
           options.casks.each do |arg|
-            found = true if app[:token] == arg || (arg.end_with?("*") && app[:token].start_with?(arg.slice(0..-2)))
+            # Support full glob patterns (*, ?, [abc], etc.)
+            if arg == app[:token]
+              found = true
+            elsif arg.match?(/[*?\[\]]/)
+              found = true if File.fnmatch(arg, app[:token], File::FNM_EXTGLOB)
+            end
           end
           found
         end
@@ -272,7 +277,7 @@ module Bcu
         end
       end
 
-      [outdated, state_info]
+      [outdated, state_info, installed]
     end
 
     def mas_load_outdated
@@ -306,7 +311,7 @@ module Bcu
 
     def install_empty_message(cask_searched)
       if cask_searched.length == 1
-        if cask_searched[0].end_with? "*"
+        if cask_searched[0].include?("*") || cask_searched[0].include?("?") || cask_searched[0].include?("[")
           "#{Tty.red}No Cask matching \"#{cask_searched[0]}\" is installed.#{Tty.reset}"
         else
           "#{Tty.red}Cask \"#{cask_searched[0]}\" is not installed.#{Tty.reset}"


### PR DESCRIPTION
## Summary

Fixes #249

This PR fixes an issue where glob patterns like `brew cu 'cl*'` would filter casks internally but display all installed casks in the output table instead of just the matching ones.

### Before
```
brew cu 'cl*'
...
9/50  claude-code  2.1.85   2.1.85       [   OK   ]  
10/50 cleanshot    4.8.8    4.8.8    Y   [  PASS  ]  
```
(Shows all 50 casks with only 2 matching)

### After
```
brew cu 'cl*'
...
1/2  claude-code  2.1.85   2.1.85       [   OK   ]  
2/2  cleanshot    4.8.8    4.8.8    Y   [  PASS  ]  
```
(Shows only the 2 matching casks)

## Changes

- **Fixed filtering logic**: `find_outdated_apps` now returns the filtered installed list to the caller
- **Enhanced glob support**: Use `File.fnmatch` for full glob syntax (`*`, `?`, `[abc]`) instead of just prefix matching
- **Improved error messages**: Handle all glob characters, not just `*`
- **Better documentation**: Added comprehensive glob pattern guide to README with quoting examples
- **Updated help text**: Emphasize the need to quote patterns to prevent shell expansion

## Test Plan

- [x] Prefix glob: `brew cu 'cl*'` matches claude-code and cleanshot
- [x] Suffix glob: `brew cu '*-code'` matches claude-code
- [x] Wildcard: `brew cu 'claude-cod?'` matches claude-code
- [x] Exact match: `brew cu cleanshot` still works
- [x] Non-matching: `brew cu 'xyz*'` shows appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)