### PR TITLE
Fix private method 'load' error with recent Homebrew

### DIFF
--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -63,14 +63,8 @@ module Cask
     installed.sort_by { |a| a[:token] }
   end
 
-  # See: https://github.com/buo/homebrew-cask-upgrade/issues/43
   def self.load_cask(token)
-    begin
-      cask = CaskLoader.load(token)
-    rescue NoMethodError
-      cask = Cask.load(token)
-    end
-    cask
+    CaskLoader.load(token)
   end
 
   # Retrieves currently installed versions on the machine.


### PR DESCRIPTION
## Summary

- Recent Homebrew made `Cask.load` a private method, causing `brew cu` to fail with `private method 'load' called for class Cask::Cask`
- The `NoMethodError` rescue fallback in `load_cask` was originally added for ancient Homebrew compatibility (when `CaskLoader.load` didn't exist)
- Since `CaskLoader.load` has been the standard API for years, removed the dead fallback and call it directly

Fixes https://github.com/buo/homebrew-cask-upgrade/issues/301

## Test plan

- [x] Run `brew cu` — confirms casks are listed without error
- [x] Run `brew cu -a` — confirms full listing works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)