### PR TITLE
Fix crash on Homebrew 5.1.7 when loading casks with bare depends_on :macos

### DIFF
--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -41,7 +41,7 @@ module Cask
           tap:                cask.tap&.name,
           mas:                false,
         }
-      rescue CaskUnavailableError, StandardError
+      rescue CaskUnavailableError, NoMethodError
         {
           cask:               nil,
           name:               nil,

--- a/lib/extend/cask.rb
+++ b/lib/extend/cask.rb
@@ -41,7 +41,7 @@ module Cask
           tap:                cask.tap&.name,
           mas:                false,
         }
-      rescue CaskUnavailableError
+      rescue CaskUnavailableError, StandardError
         {
           cask:               nil,
           name:               nil,


### PR DESCRIPTION
Homebrew 5.1.7 ships with a bug in `CaskStructGenerator#process_depends_on` (introduced by [Homebrew/brew#22006](https://github.com/Homebrew/brew/pull/22006)): casks using bare `depends_on :macos` (no version) cause `dep_type` to be `nil`, and the subsequent `dep_type.to_sym` call crashes. The fix landed in Homebrew master but wasn't included in 5.1.7.

## Changes

- **`lib/extend/cask.rb`**: Add `NoMethodError` alongside `CaskUnavailableError` in the cask-loading rescue block so affected casks degrade gracefully to "no cask available" instead of aborting the entire `brew cu` run.

```ruby
# before
rescue CaskUnavailableError

# after
rescue CaskUnavailableError, NoMethodError
```

Once Homebrew ships the fix, the added rescue clause becomes a no-op.