### PR TITLE
Fix "can't modify frozen Array" crash on `brew update`

### DIFF
--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -71,4 +71,16 @@ $LOAD_PATH.unshift(File.expand_path("../../lib", Pathname.new(__FILE__).realpath
 
 require "bcu"
 
-Bcu.process(ARGV)
+# Homebrew loads external Ruby commands in-process via `require`, including
+# during the completion/manpage rebuild that runs on every `brew update`.
+# Without a guard, `Bcu.process` would execute on each `brew update` and, on
+# recent Homebrew, crash with "can't modify frozen Array" because OptionParser
+# mutates the now-frozen ARGV. Only run when actually invoked as `brew cu`.
+invoked_as_cu =
+  if Homebrew.respond_to?(:running_command_with_args)
+    Homebrew.running_command_with_args.split[1] == "cu"
+  else
+    File.basename($PROGRAM_NAME, ".rb") == "brew-cu"
+  end
+
+Bcu.process(ARGV) if invoked_as_cu


### PR DESCRIPTION
### Problem

On recent Homebrew (5.x), every `brew update` ends with:

```
Error: can't modify frozen Array: []
.../vendor/portable-ruby/.../optparse.rb:1735:in 'Array#shift'
.../lib/bcu/options.rb:138:in 'Bcu.parse!'
.../lib/bcu.rb:21:in 'Bcu.process'
.../cmd/brew-cu.rb:74:in '<main>'
.../Homebrew/cli/parser.rb:61:in 'from_cmd_path'
.../Homebrew/completions.rb:151:in 'command_hidden_from_manpage?'
.../Homebrew/commands.rb:231:in 'rebuild_commands_completion_list'
.../Homebrew/cmd/update-report.rb:204:in 'output_update_report'
```

### Root cause

`cmd/brew-cu.rb` calls `Bcu.process(ARGV)` unconditionally at the top level.
Homebrew loads external Ruby commands **in-process via `require`** (see
`brew.rb` → `Homebrew.require?(external_ruby_cmd_path)`), and `brew update`
re-`require`s every command file to rebuild the command-completion / manpage
list (`rebuild_commands_completion_list` → `command_hidden_from_manpage?` →
`Parser.from_cmd_path`).

That side-effect `require` runs `Bcu.process(ARGV)` outside any real `brew cu`
invocation. Recent Homebrew now freezes `ARGV` (`ARGV.freeze` in
`cli/parser.rb`), so `OptionParser#parse!` raises `FrozenError` when it tries to
`shift` it. Even without the freeze, this means `Bcu.process` would silently run
on every `brew update`, which is also wrong.

### Fix

Guard the top-level call so `Bcu.process` only runs when the file is actually
invoked as `brew cu`, using Homebrew's `running_command_with_args` (with a
`$PROGRAM_NAME` fallback for older/standalone execution).

### Testing

- `brew update` → exits 0, no error (previously crashed).
- `brew cu`, `brew cu pinned` → work as before.