### PR TITLE
Fix "can't modify frozen Array" crash on brew update

### DIFF
--- a/cmd/brew-cu.rb
+++ b/cmd/brew-cu.rb
@@ -71,4 +71,16 @@ $LOAD_PATH.unshift(File.expand_path("../../lib", Pathname.new(__FILE__).realpath
 
 require "bcu"
 
-Bcu.process(ARGV)
+# Homebrew loads external Ruby commands in-process via `require`, including
+# during the completion/manpage rebuild that runs on every `brew update`.
+# Without a guard, `Bcu.process` would execute on each `brew update` and, on
+# recent Homebrew, crash with "can't modify frozen Array" because OptionParser
+# mutates the now-frozen ARGV. Only run when actually invoked as `brew cu`.
+invoked_as_cu =
+  if Homebrew.respond_to?(:running_command_with_args)
+    Homebrew.running_command_with_args.split[1] == "cu"
+  else
+    File.basename($PROGRAM_NAME, ".rb") == "brew-cu"
+  end
+
+Bcu.process(ARGV) if invoked_as_cu

--- a/lib/bcu/options.rb
+++ b/lib/bcu/options.rb
@@ -135,6 +135,9 @@ module Bcu
       end
     end
 
+    # Dup so OptionParser never mutates a caller-supplied (possibly frozen)
+    # array such as Homebrew's ARGV.
+    args = args.dup
     parser.parse!(args)
 
     if %w[pin unpin pinned livecheck run].include?(args[0])


### PR DESCRIPTION
Homebrew loads external tap commands in-process via `require`, including during the completion/manpage rebuild that runs on every `brew update` and `brew tap`. Because cmd/brew-cu.rb called `Bcu.process(ARGV)` unconditionally at load time, it ran with the outer command's frozen ARGV, and OptionParser#parse! mutating that array raised "can't modify frozen Array".

Guard the entrypoint so `Bcu.process` only runs when actually invoked as `brew cu`, which also prevents a spurious cask scan and nested-update lock errors during `brew update`. As defense-in-depth, dup the args in Bcu.parse! so OptionParser never mutates a caller-supplied frozen array.

Duplicate of #307 on latest master.

Fixes #308 